### PR TITLE
Remove redundant dag%n component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ endif()
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall -std=f2018")
+  get_filename_component(barename ${CMAKE_Fortran_COMPILER} NAME)
+  if("${barename}" MATCHES gfortran)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fcoarray=single")
+  endif()
 endif()
 
 set(CMAKE_Fortran_MODULE_DIRECTORY "${PROJECT_BINARY_DIR}/mod")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,8 @@ add_library(dag
   dag_implementation.F90
   vertex_interface.F90
   vertex_implementation.f90
+  assert_implementation.f90
+  assert_interface.f90
 )
 target_link_libraries(dag
   PRIVATE jsonfortran-static

--- a/src/assert_implementation.f90
+++ b/src/assert_implementation.f90
@@ -1,0 +1,13 @@
+submodule(assert_interface) assert_implementation
+
+  implicit none
+
+contains
+
+  module procedure assert
+
+    if (.not. assertion) error stop description
+
+  end procedure
+
+end submodule assert_implementation

--- a/src/assert_interface.f90
+++ b/src/assert_interface.f90
@@ -1,0 +1,16 @@
+module assert_interface
+  implicit none
+
+  private
+  public :: assert
+
+  interface
+
+    pure module subroutine assert(assertion, description)
+      logical, intent(in) :: assertion
+      character(len=*), intent(in) :: description
+    end subroutine
+
+  end interface
+
+end module assert_interface

--- a/src/dag_implementation.F90
+++ b/src/dag_implementation.F90
@@ -1,17 +1,8 @@
-!*******************************************************************************
-!>
-!  DAG Module.
-
     submodule(dag_interface) dag_implementation
 
     implicit none
 
 contains
-
-!*******************************************************************************
-!>
-!  get the edges for the vertex (all the the vertices
-!  that this vertex depends on).
 
     module procedure dag_get_edges
 
@@ -20,11 +11,6 @@ contains
     end if
 
     end procedure
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  get all the vertices that depend on this vertex.
 
     module procedure dag_get_dependencies
 
@@ -50,11 +36,6 @@ contains
     end if
 
     end procedure
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  set the number of vertices in the dag
 
     module procedure dag_set_vertices
 
@@ -65,11 +46,6 @@ contains
     call me%vertices%set_vertex_id( [(i,i=1,nvertices)] )
 
     end procedure
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  set info about a vertex in a dag.
 
     module procedure dag_set_vertex_info
 
@@ -83,22 +59,12 @@ contains
     if (present(attributes)) call me%vertices(ivertex)%set_attributes(attributes)
 
     end procedure
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  set the edges for a vertex in a dag
 
     module procedure dag_set_edges
 
     call me%vertices(ivertex)%set_edges(edges)
 
     end procedure
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  Main toposort routine
 
     module procedure dag_toposort
 
@@ -158,15 +124,6 @@ contains
 #ifndef FORD
     end procedure dag_toposort
 #endif
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  Generate a Graphviz digraph structure for the DAG.
-!
-!### Example
-!  * To convert this to a PDF using `dot`: `dot -Tpdf -o test.pdf test.dot`,
-!    where `test.dot` is `str` written to a file.
 
     module procedure dag_generate_digraph
 
@@ -225,14 +182,6 @@ contains
     str = str//newline//'}'
 
     end procedure dag_generate_digraph
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  Generate the dependency matrix for the DAG.
-!
-!  This is an \(n \times n \) matrix with elements \(A_{ij}\),
-!  such that \(A_{ij}\) is true if vertex \(i\) depends on vertex \(j\).
 
     module procedure dag_generate_dependency_matrix
 
@@ -254,11 +203,6 @@ contains
     end if
 
     end procedure
-!*******************************************************************************
-
-!*******************************************************************************
-!>
-!  Generate a Graphviz digraph structure for the DAG and write it to a file.
 
     module procedure dag_save_digraph
 
@@ -280,12 +224,6 @@ contains
     close(iunit,iostat=istat)
 
     end procedure
-!*******************************************************************************
-
-
-!*******************************************************************************
-!>
-!  Integer to allocatable string.
 
     pure function integer_to_string(i) result(s)
 
@@ -305,11 +243,7 @@ contains
     end if
 
     end function integer_to_string
-!*******************************************************************************
 
-!*******************************************************************************
-!>
-! Write DAG to JSON file
   module procedure output
     use json_module, wp => json_RK, IK => json_IK, LK => json_LK
     use, intrinsic :: iso_fortran_env , only: error_unit
@@ -428,7 +362,5 @@ contains
     end subroutine
 
     end procedure
-!*******************************************************************************
 
     end submodule dag_implementation
-!*******************************************************************************

--- a/src/dag_implementation.F90
+++ b/src/dag_implementation.F90
@@ -1,43 +1,41 @@
-    submodule(dag_interface) dag_implementation
+submodule(dag_interface) dag_implementation
 
-    implicit none
+  implicit none
 
 contains
 
-    module procedure dag_get_edges
+  module procedure dag_get_edges
 
     if (ivertex>0 .and. ivertex <= me%n) then
-        edges = me%vertices(ivertex)%edges  ! auto LHS allocation
+      edges = me%vertices(ivertex)%edges  ! auto LHS allocation
     end if
 
-    end procedure
+  end procedure
 
-    module procedure dag_get_dependencies
-
-    implicit none
+  module procedure dag_get_dependencies
 
     integer :: i !! vertex counter
 
     if (ivertex>0 .and. ivertex <= me%n) then
 
-        ! have to check all the vertices:
-        do i=1, me%n
-            if (allocated(me%vertices(i)%edges)) then
-                if (any(me%vertices(i)%edges == ivertex)) then
-                    if (allocated(dep)) then
-                        dep = [dep, i]  ! auto LHS allocation
-                    else
-                        dep = [i]       ! auto LHS allocation
-                    end if
-                end if
-            end if
-        end do
+      ! have to check all the vertices:
+      do i=1, me%n
+          if (allocated(me%vertices(i)%edges)) then
+              if (any(me%vertices(i)%edges == ivertex)) then
+                  if (allocated(dep)) then
+                      dep = [dep, i]  ! auto LHS allocation
+                  else
+                      dep = [i]       ! auto LHS allocation
+                  end if
+              end if
+          end if
+      end do
 
     end if
 
-    end procedure
+  end procedure
 
-    module procedure dag_set_vertices
+  module procedure dag_set_vertices
 
     integer :: i
 
@@ -45,9 +43,9 @@ contains
     allocate(me%vertices(nvertices))
     call me%vertices%set_vertex_id( [(i,i=1,nvertices)] )
 
-    end procedure
+  end procedure
 
-    module procedure dag_set_vertex_info
+  module procedure dag_set_vertex_info
 
     if (present(label)) then
         call me%vertices(ivertex)%set_label(label)
@@ -58,15 +56,15 @@ contains
 
     if (present(attributes)) call me%vertices(ivertex)%set_attributes(attributes)
 
-    end procedure
+  end procedure
 
-    module procedure dag_set_edges
+  module procedure dag_set_edges
 
     call me%vertices(ivertex)%set_edges(edges)
 
-    end procedure
+  end procedure
 
-    module procedure dag_toposort
+  module procedure dag_toposort
 
     integer :: i,iorder
 
@@ -84,50 +82,48 @@ contains
     if (istat==-1) deallocate(order)
 
 #ifndef FORD
-    contains
+  contains
 #else
     end procedure ! work around ford documentation generator bug
 #endif
 
     recursive subroutine dfs(v)
 
-    !! depth-first graph traversal
+        !! depth-first graph traversal
 
-    type(vertex),intent(inout) :: v
-    integer :: j
+      type(vertex),intent(inout) :: v
+      integer :: j
 
-    if (istat==-1) return
+      if (istat==-1) return
 
-    associate( v_checking => v%get_checking(), v_marked => v%get_marked())
-      if (v_checking) then
-        ! error: circular dependency
-        istat = -1
-      else
-        if (.not. v_marked) then
-          call v%set_checking(.true.)
-          if (allocated(v%edges)) then
-            do j=1,size(v%edges)
-              call dfs(me%vertices(v%edges(j)))
-              if (istat==-1) return
-            end do
+      associate( v_checking => v%get_checking(), v_marked => v%get_marked())
+        if (v_checking) then
+          ! error: circular dependency
+          istat = -1
+        else
+          if (.not. v_marked) then
+            call v%set_checking(.true.)
+            if (allocated(v%edges)) then
+              do j=1,size(v%edges)
+                call dfs(me%vertices(v%edges(j)))
+                if (istat==-1) return
+              end do
+            end if
+            call v%set_checking(.false.)
+            call v%set_marked(.true.)
+            iorder = iorder + 1
+            order(iorder) = v%get_vertex_id()
           end if
-          call v%set_checking(.false.)
-          call v%set_marked(.true.)
-          iorder = iorder + 1
-          order(iorder) = v%get_vertex_id()
         end if
-      end if
-    end associate
+      end associate
 
     end subroutine dfs
 
 #ifndef FORD
-    end procedure dag_toposort
+  end procedure dag_toposort
 #endif
 
-    module procedure dag_generate_digraph
-
-    implicit none
+  module procedure dag_generate_digraph
 
     integer :: i,j     !! counter
     integer :: n_edges !! number of edges
@@ -181,11 +177,9 @@ contains
 
     str = str//newline//'}'
 
-    end procedure dag_generate_digraph
+  end procedure dag_generate_digraph
 
-    module procedure dag_generate_dependency_matrix
-
-    implicit none
+  module procedure dag_generate_dependency_matrix
 
     integer :: i !! vertex counter
 
@@ -202,11 +196,9 @@ contains
 
     end if
 
-    end procedure
+  end procedure
 
-    module procedure dag_save_digraph
-
-    implicit none
+  module procedure dag_save_digraph
 
     integer :: iunit, istat
     character(len=:),allocatable :: diagraph
@@ -223,11 +215,9 @@ contains
 
     close(iunit,iostat=istat)
 
-    end procedure
+  end procedure
 
-    pure function integer_to_string(i) result(s)
-
-    implicit none
+  pure function integer_to_string(i) result(s)
 
     integer,intent(in) :: i
     character(len=:),allocatable :: s
@@ -242,7 +232,7 @@ contains
         s = '***'
     end if
 
-    end function integer_to_string
+  end function integer_to_string
 
   module procedure output
     use json_module, wp => json_RK, IK => json_IK, LK => json_LK
@@ -361,6 +351,6 @@ contains
 
     end subroutine
 
-    end procedure
+  end procedure
 
-    end submodule dag_implementation
+end submodule dag_implementation

--- a/src/dag_implementation.F90
+++ b/src/dag_implementation.F90
@@ -340,15 +340,15 @@ contains
       call increment_if_error(json, error_cnt)
 
 #ifdef __GFORTRAN__
-      call add_intrinsic_variable(json, graph, me%vertices(i)%edges, 'edges', error_cnt, var)
+      call add_intrinsic_variable(json, me%vertices(i)%edges, 'edges', error_cnt, var)
 #else
-      call add_intrinsic_variable(json, graph, me%vertices(i)%get_edges(), 'edges', error_cnt, var)
+      call add_intrinsic_variable(json, me%vertices(i)%get_edges(), 'edges', error_cnt, var)
 #endif
-      call add_intrinsic_variable(json, graph, me%vertices(i)%get_vertex_id(), 'ivertex', error_cnt, var)
-      call add_intrinsic_variable(json, graph, me%vertices(i)%get_checking(), 'checking', error_cnt, var)
-      call add_intrinsic_variable(json, graph, me%vertices(i)%get_marked(), 'marked', error_cnt, var)
-      call add_intrinsic_variable(json, graph, me%vertices(i)%get_label(), 'label', error_cnt, var)
-      call add_intrinsic_variable(json, graph, me%vertices(i)%get_attributes(), 'attributes', error_cnt, var)
+      call add_intrinsic_variable(json, me%vertices(i)%get_vertex_id(), 'ivertex', error_cnt, var)
+      call add_intrinsic_variable(json, me%vertices(i)%get_checking(), 'checking', error_cnt, var)
+      call add_intrinsic_variable(json, me%vertices(i)%get_marked(), 'marked', error_cnt, var)
+      call add_intrinsic_variable(json, me%vertices(i)%get_label(), 'label', error_cnt, var)
+      call add_intrinsic_variable(json, me%vertices(i)%get_attributes(), 'attributes', error_cnt, var)
 
       call json%add(graph, var)
       call increment_if_error(json, error_cnt)
@@ -392,9 +392,8 @@ contains
       end if
     end subroutine
 
-    subroutine add_intrinsic_variable(json, me, variable, variable_name, error_cnt, var)
+    subroutine add_intrinsic_variable(json, variable, variable_name, error_cnt, var)
       type(json_core),intent(inout) :: json
-      type(json_value), pointer, intent(inout) :: me
       class(*), intent(in) :: variable(..)
       character(len=*), intent(in) :: variable_name
       integer, intent(inout) :: error_cnt

--- a/src/dag_interface.f90
+++ b/src/dag_interface.f90
@@ -14,7 +14,6 @@
     type,public :: dag
         !! a directed acyclic graph (DAG)
         private
-        integer :: n = unset !! number of `vertices`
         type(vertex),dimension(:),allocatable :: vertices  !! the vertices in the DAG.
     contains
         procedure,public :: set_vertices     => dag_set_vertices

--- a/src/vertex_implementation.f90
+++ b/src/vertex_implementation.f90
@@ -42,6 +42,10 @@ contains
     my_vertex_id = me%ivertex
   end procedure
 
+  module procedure get_edges
+    my_edges = me%edges
+  end procedure
+
   module procedure get_checking
     my_checking = me%checking
   end procedure

--- a/src/vertex_interface.F90
+++ b/src/vertex_interface.F90
@@ -28,6 +28,7 @@
         procedure :: set_vertex_id
         procedure :: set_label
         procedure :: set_attributes
+        procedure :: get_edges
         procedure :: get_vertex_id
         procedure :: get_checking
         procedure :: get_marked
@@ -114,6 +115,17 @@ interface
     implicit none
     class(vertex), intent(in) :: me
     integer my_vertex_id
+    end function
+!*******************************************************************************
+
+!*******************************************************************************
+!>
+!  result is an array of the vertex identifiers on which this vertex depends
+
+    pure module function get_edges(me) result(my_edges)
+    implicit none
+    class(vertex), intent(in) :: me
+    integer :: my_edges(size(me%edges))
     end function
 !*******************************************************************************
 


### PR DESCRIPTION
The `dag%n` component held the value of `size(dag%vertices)`, which poses the danger of the redundant information becoming out-of-sync with the actual value if it changes and adds unnecessary code.