### PR TITLE
Add example of printing labels in a digraph

### DIFF
--- a/example/feats-dependency-tree.f90
+++ b/example/feats-dependency-tree.f90
@@ -13,12 +13,12 @@ program labeled_dag_output
     ! a topologically sorted enumeration of the items in the dependency tree
     enumerator :: &
     build_feats=1, application_generator_m, image_m, data_location_map_m, application_m, dag_interface, task_item_m, & 
-    payload_m, task_m, mailbox_m, assertions_interface, application_s, payload_s, data_location_map_s, image_s, task_item_s
+    payload_m, task_m, mailbox_m, assert_m, application_s, payload_s, data_location_map_s, image_s, task_item_s
   end enum
 
   integer, parameter :: vertices(*) = [ &
     build_feats,   application_generator_m, image_m, data_location_map_m, application_m, dag_interface, task_item_m, & 
-    payload_m, task_m, mailbox_m, assertions_interface, application_s, payload_s, data_location_map_s, image_s, task_item_s &
+    payload_m, task_m, mailbox_m, assert_m, application_s, payload_s, data_location_map_s, image_s, task_item_s &
   ]
   integer, parameter :: num_vertices = size(vertices)
 
@@ -34,7 +34,7 @@ program labeled_dag_output
   name_list(payload_m              ) = module_name_t("payload_m")
   name_list(task_m                 ) = module_name_t("task_m")
   name_list(mailbox_m              ) = module_name_t("mailbox_m")
-  name_list(assertions_interface   ) = module_name_t("assertions_interface")
+  name_list(assert_m   ) = module_name_t("assert_m")
   name_list(application_s          ) = module_name_t("application_s")
   name_list(payload_s              ) = module_name_t("payload_s")
   name_list(data_location_map_s    ) = module_name_t("data_location_map_s")
@@ -46,7 +46,7 @@ program labeled_dag_output
     integer i
 
     do i = 1, num_vertices
-      call module_dependencies%set_vertex_info(i, label=name_list(i)%module_name)
+      call module_dependencies%set_vertex_label(i, name_list(i)%module_name)
     end do
 
   end block
@@ -56,7 +56,7 @@ program labeled_dag_output
   call module_dependencies%set_edges(task_item_m, [data_location_map_m, payload_m, task_m])
   call module_dependencies%set_edges(task_m, [data_location_map_m, payload_m])
   call module_dependencies%set_edges(mailbox_m, [payload_m])
-  call module_dependencies%set_edges(application_s, [application_m, assertions_interface])
+  call module_dependencies%set_edges(application_s, [application_m, assert_m])
   call module_dependencies%set_edges(payload_s, [payload_m])
   call module_dependencies%set_edges(data_location_map_s, [data_location_map_m])
   call module_dependencies%set_edges(image_s, [image_m])
@@ -68,11 +68,11 @@ program labeled_dag_output
     character(len=len(non_leaf_color)), parameter :: leaf_color     = 'shape=circle,fillcolor="cornsilk",style=filled'
     integer, parameter :: leaf_nodes(*) = &
       [application_generator_m, data_location_map_m, dag_interface, payload_m, &
-      assertions_interface, application_s, payload_s, data_location_map_s, image_s, task_item_s]
+      assert_m, application_s, payload_s, data_location_map_s, image_s, task_item_s]
     
     do i = 1, num_vertices
       associate(node_color => merge(leaf_color, non_leaf_color, any(i==leaf_nodes)))
-        call module_dependencies%set_vertex_info(i, attributes = node_color)
+        call module_dependencies%set_vertex_attributes(i, node_color)
       end associate
     end do
 
@@ -85,7 +85,7 @@ program labeled_dag_output
 
     call module_dependencies%save_digraph(digraph_file, 'RL', 300)
     call execute_command_line('dot -Tpdf -o ' // output_file // ' ' // digraph_file)
-    print *, new_line(''), " ----- application_generator(): module_depenencies DAG written to " // output_file
+    print *, new_line(''), " main: module_depenencies DAG written to " // output_file
   end block
 
 end program

--- a/example/feats-dependency-tree.f90
+++ b/example/feats-dependency-tree.f90
@@ -1,0 +1,91 @@
+program labeled_dag_output
+  use dag_interface, only : dag_t
+  implicit none
+
+  type module_name_t
+    character(len=:), allocatable :: module_name
+  end type
+
+  type(module_name_t), allocatable :: name_list(:)
+  type(dag_t) :: module_dependencies
+
+  enum, bind(C)
+    ! a topologically sorted enumeration of the items in the dependency tree
+    enumerator :: &
+    build_feats=1, application_generator_m, image_m, data_location_map_m, application_m, dag_interface, task_item_m, & 
+    payload_m, task_m, mailbox_m, assertions_interface, application_s, payload_s, data_location_map_s, image_s, task_item_s
+  end enum
+
+  integer, parameter :: vertices(*) = [ &
+    build_feats,   application_generator_m, image_m, data_location_map_m, application_m, dag_interface, task_item_m, & 
+    payload_m, task_m, mailbox_m, assertions_interface, application_s, payload_s, data_location_map_s, image_s, task_item_s &
+  ]
+  integer, parameter :: num_vertices = size(vertices)
+
+  allocate(name_list(num_vertices))
+
+  name_list(build_feats)             = module_name_t("build_feats")
+  name_list(application_generator_m) = module_name_t("application_generator_m")
+  name_list(image_m                ) = module_name_t("image_m")
+  name_list(data_location_map_m    ) = module_name_t("data_location_map_m")
+  name_list(application_m          ) = module_name_t("application_m")
+  name_list(dag_interface          ) = module_name_t("dag_interface")
+  name_list(task_item_m            ) = module_name_t("task_item_m")
+  name_list(payload_m              ) = module_name_t("payload_m")
+  name_list(task_m                 ) = module_name_t("task_m")
+  name_list(mailbox_m              ) = module_name_t("mailbox_m")
+  name_list(assertions_interface   ) = module_name_t("assertions_interface")
+  name_list(application_s          ) = module_name_t("application_s")
+  name_list(payload_s              ) = module_name_t("payload_s")
+  name_list(data_location_map_s    ) = module_name_t("data_location_map_s")
+  name_list(image_s                ) = module_name_t("image_s")
+  name_list(task_item_s            ) = module_name_t("task_item_s")
+
+  call module_dependencies%set_vertices(num_vertices)
+  block 
+    integer i
+
+    do i = 1, num_vertices
+      call module_dependencies%set_vertex_info(i, label=name_list(i)%module_name)
+    end do
+
+  end block
+  call module_dependencies%set_edges(build_feats, [application_generator_m, image_m])   
+  call module_dependencies%set_edges(image_m, [data_location_map_m, application_m])
+  call module_dependencies%set_edges(application_m, [dag_interface, task_item_m])
+  call module_dependencies%set_edges(task_item_m, [data_location_map_m, payload_m, task_m])
+  call module_dependencies%set_edges(task_m, [data_location_map_m, payload_m])
+  call module_dependencies%set_edges(mailbox_m, [payload_m])
+  call module_dependencies%set_edges(application_s, [application_m, assertions_interface])
+  call module_dependencies%set_edges(payload_s, [payload_m])
+  call module_dependencies%set_edges(data_location_map_s, [data_location_map_m])
+  call module_dependencies%set_edges(image_s, [image_m])
+  call module_dependencies%set_edges(task_item_s, [task_item_m])
+ 
+  block
+    integer i
+    character(len=*),                   parameter :: non_leaf_color = 'shape=square,fillcolor="SlateGray1",style=filled'
+    character(len=len(non_leaf_color)), parameter :: leaf_color     = 'shape=circle,fillcolor="cornsilk",style=filled'
+    integer, parameter :: leaf_nodes(*) = &
+      [application_generator_m, data_location_map_m, dag_interface, payload_m, &
+      assertions_interface, application_s, payload_s, data_location_map_s, image_s, task_item_s]
+    
+    do i = 1, num_vertices
+      associate(node_color => merge(leaf_color, non_leaf_color, any(i==leaf_nodes)))
+        call module_dependencies%set_vertex_info(i, attributes = node_color)
+      end associate
+    end do
+
+  end block
+
+  block
+    character(len=*), parameter :: base_name= 'feats-dependencies'
+    character(len=*), parameter :: digraph_file = base_name // '.dot'
+    character(len=*), parameter :: output_file = base_name // '.pdf'
+
+    call module_dependencies%save_digraph(digraph_file, 'RL', 300)
+    call execute_command_line('dot -Tpdf -o ' // output_file // ' ' // digraph_file)
+    print *, new_line(''), " ----- application_generator(): module_depenencies DAG written to " // output_file
+  end block
+
+end program

--- a/src/dag_implementation.f90
+++ b/src/dag_implementation.f90
@@ -106,6 +106,14 @@ contains
   end procedure
 
 !*******************************************************************************
+  module procedure set_vertex_label
+    call me%vertices(ivertex)%set_label(label)
+  end procedure
+!*******************************************************************************
+  module procedure set_vertex_attributes
+    call me%vertices(ivertex)%set_attributes(attributes)
+  end procedure
+!*******************************************************************************
 
   module procedure dag_set_vertex_info
 
@@ -201,12 +209,25 @@ contains
     if (present(dpi)) &
         str = str//tab//'graph [ dpi = '//integer_to_string(dpi)//' ]'//newline//newline
 
+    block
+      logical, parameter :: temporary_debugging=.true.
+
+      if (temporary_debugging) print *,"size(me%vertices) ", size(me%vertices)
+    end block
+
     ! define the vertices:
     do i=1,size(me%vertices)
       associate( &
         has_label      => me%vertices(i)%has_label(), &
         has_attributes => me%vertices(i)%has_attributes() &
       )
+
+        block
+          logical, parameter :: temporary_debugging=.true.
+
+          if (temporary_debugging) print *,"vertex ",i," has label ", trim(adjustl(me%vertices(i)%get_label()))
+        end block
+
         if (has_label) label = 'label="'//trim(adjustl(me%vertices(i)%get_label()))//'"'
         if (has_label .and. has_attributes) then
             attributes = '['//trim(adjustl(me%vertices(i)%get_attributes()))//','//label//']'
@@ -270,7 +291,9 @@ contains
     integer :: iunit, istat
     character(len=:),allocatable :: diagraph
 
+    print *,"dag_dave_digraph: calling generate_digraph"
     diagraph = me%generate_digraph(rankdir,dpi)
+    print *,"dag_dave_digraph: generate_digraph completed"
 
     open(newunit=iunit,file=filename,status='REPLACE',iostat=istat)
 

--- a/src/dag_implementation.f90
+++ b/src/dag_implementation.f90
@@ -210,24 +210,12 @@ contains
     if (present(dpi)) &
         str = str//tab//'graph [ dpi = '//integer_to_string(dpi)//' ]'//newline//newline
 
-    block
-      logical, parameter :: temporary_debugging=.true.
-
-      if (temporary_debugging) print *,"size(me%vertices) ", size(me%vertices)
-    end block
-
     ! define the vertices:
     do i=1,size(me%vertices)
       associate( &
         has_label      => me%vertices(i)%has_label(), &
         has_attributes => me%vertices(i)%has_attributes() &
       )
-
-        block
-          logical, parameter :: temporary_debugging=.true.
-
-          if (temporary_debugging) print *,"vertex ",i," has label ", trim(adjustl(me%vertices(i)%get_label()))
-        end block
 
         if (has_label) label = 'label="'//trim(adjustl(me%vertices(i)%get_label()))//'"'
         if (has_label .and. has_attributes) then
@@ -292,9 +280,7 @@ contains
     integer :: iunit, istat
     character(len=:),allocatable :: diagraph
 
-    print *,"dag_dave_digraph: calling generate_digraph"
     diagraph = me%generate_digraph(rankdir,dpi)
-    print *,"dag_dave_digraph: generate_digraph completed"
 
     open(newunit=iunit,file=filename,status='REPLACE',iostat=istat)
 

--- a/src/dag_implementation.f90
+++ b/src/dag_implementation.f90
@@ -106,25 +106,26 @@ contains
   end procedure
 
 !*******************************************************************************
+
   module procedure set_vertex_label
-    call me%vertices(ivertex)%set_label(label)
-  end procedure
-!*******************************************************************************
-  module procedure set_vertex_attributes
-    call me%vertices(ivertex)%set_attributes(attributes)
-  end procedure
-!*******************************************************************************
-
-  module procedure dag_set_vertex_info
-
     if (present(label)) then
         call me%vertices(ivertex)%set_label(label)
     else
         call me%vertices(ivertex)%set_label(integer_to_string(ivertex))
     end if
+  end procedure
 
-    if (present(attributes)) call me%vertices(ivertex)%set_attributes(attributes)
+!*******************************************************************************
 
+  module procedure set_vertex_attributes
+    call me%vertices(ivertex)%set_attributes(attributes)
+  end procedure
+
+!*******************************************************************************
+
+  module procedure dag_set_vertex_info
+    call me%set_vertex_label(ivertex, label)
+    call me%set_vertex_attributes(ivertex, attributes)
   end procedure
 
 !*******************************************************************************

--- a/src/dag_interface.f90
+++ b/src/dag_interface.f90
@@ -225,7 +225,7 @@ module dag_interface
         implicit none
         class(dag_t), intent(inout)  :: me
         integer, intent(in)          :: ivertex
-        character(len=*), intent(in) :: label
+        character(len=*), intent(in), optional :: label
       end subroutine
 !*******************************************************************************
       module subroutine set_vertex_attributes(me, ivertex, attributes)

--- a/src/dag_interface.f90
+++ b/src/dag_interface.f90
@@ -158,7 +158,8 @@ module dag_interface
     contains
         procedure,public  :: to_json
         procedure,private :: generate_digraph           => dag_generate_digraph
-
+        procedure         :: set_vertex_label
+        procedure         :: set_vertex_attributes
         procedure,public  :: set_vertices               => dag_set_vertices
         procedure,public  :: set_edges                  => dag_set_edges
         procedure,public  :: set_vertex_info            => dag_set_vertex_info
@@ -219,6 +220,20 @@ module dag_interface
          class(dag_t),intent(inout)         :: me
          integer,intent(in)               :: nvertices
        end subroutine dag_set_vertices
+!*******************************************************************************
+      module subroutine set_vertex_label(me, ivertex, label)
+        implicit none
+        class(dag_t), intent(inout)  :: me
+        integer, intent(in)          :: ivertex
+        character(len=*), intent(in) :: label
+      end subroutine
+!*******************************************************************************
+      module subroutine set_vertex_attributes(me, ivertex, attributes)
+        implicit none
+        class(dag_t), intent(inout)  :: me
+        integer, intent(in)          :: ivertex
+        character(len=*), intent(in) :: attributes
+      end subroutine
 !*******************************************************************************
        module subroutine dag_set_vertex_info(me,ivertex,label,attributes)
          implicit none


### PR DESCRIPTION
This pull request
1. Adds an example in the `example/` subdirectory.  The example creates a PDF file depicting a DAG graph with `character` labels for each node. 
2. Augments the `dag_t` type with two new single-component setters, `set_vertex_label` and `set_vertex_attribute`, that have safer behavior than the previous two-component setter `set_vertex_info`.  Calling the older two-component setter with  just the `attributes` argument present has the surprising side effect of overwriting the `label` component `label` if the corresponding argument is not present.